### PR TITLE
Update Economics Tags

### DIFF
--- a/tags.json
+++ b/tags.json
@@ -42,7 +42,6 @@
         "Fiscal Policy",
         "Monetary Policy", 
         "Labour Productivity",
-        "Globalisation",
         
         
     ],

--- a/tags.json
+++ b/tags.json
@@ -26,22 +26,23 @@
         "Theory"
     ],
     "econs": [
-        "Multi Choice",
+        "Multiple-choice",
         "Short Answer",
         "Extended Response",
-        "Free Trade", 
-        "AE Model",
-        "BTC", 
-        "AD/AS Model",
         "International Trade",
-        "Exchange Rates",
-        "Labour Productitivty",
-        "Globalisaiton",
-        "A+C Advantages", 
+        "Comparative Advantage", 
+        "Free Trade and Protection", 
         "Balance of Payments",
+        "Terms of Trade",
+        "Exchange Rates",
+        "Foreign Investment",
+        "Business Trade Cycle",
+        "Aggregate Expenditure",
+        "Aggregate Demand and Supply",
         "Fiscal Policy",
         "Monetary Policy", 
-        "Multiplier"
+        "Labour Productivity",
+        "Globalisation",
         
         
     ],

--- a/tagsV2.json
+++ b/tagsV2.json
@@ -138,5 +138,25 @@
         "Graphing": [], 
         "Proofs": [], 
         "Geometry": []
-    }
+    },
+    "econs": [
+        "Multiple-choice",
+        "Short Answer",
+        "Extended Response",
+        "International Trade",
+        "Comparative Advantage", 
+        "Free Trade and Protection", 
+        "Balance of Payments",
+        "Terms of Trade",
+        "Exchange Rates",
+        "Foreign Investment",
+        "Business Trade Cycle",
+        "Aggregate Expenditure",
+        "Aggregate Demand and Supply",
+        "Fiscal Policy",
+        "Monetary Policy", 
+        "Labour Productivity",
+        
+        
+    ]
 }


### PR DESCRIPTION
Economics tags updated, typos fixed and new tags added

**Changes:**
MultiChoice --> Multiple-choice (in line with official name used by SCSA)

A+C Advantages --> Comparative Advantage
- Absolute advantage is never a standalone topic
- Comparative advantage, while a part of free trade and protection, can be separated into its own tag as an important concept

AE Model --> Aggregate Expenditure (concept on its own)
AD/AS Model --> Aggregate Demand and Supply (concept on its own)

BTC --> The Business Cycle (clarity + acronym should never be used in responses)

Terms of Trade tag added
Foreign Investment tag added

Globalisation tag removed (no longer in course)