### PR TITLE
Update tagsV2: Econs Sub-tags

### DIFF
--- a/tagsV2.json
+++ b/tagsV2.json
@@ -31,15 +31,18 @@
         "Multiple-choice": [],
         "Short Answer": [],
         "Extended Response": [],
-        "International Trade": [],
-        "Comparative Advantage": [], 
+        "International Trade": [
+            "Comparative Advantage"
+        ],
         "Free Trade and Protection": [], 
         "Balance of Payments": [],
         "Terms of Trade": [],
         "Exchange Rates": [],
         "Foreign Investment": [],
         "Business Trade Cycle": [],
-        "Aggregate Expenditure": [],
+        "Aggregate Expenditure": [
+            "The Consumption Function"
+        ],
         "Aggregate Demand and Supply": [],
         "Fiscal Policy": [],
         "Monetary Policy": [], 


### PR DESCRIPTION
Added sub-tags for economics:
- Comparative Advantage --> moved under International Trade
- + The Consumption Function under Aggregate Expenditure